### PR TITLE
Invoke retainWhitespaceAndFormat with leaf.strikeThrough

### DIFF
--- a/test/serialize/__snapshots__/serialize-leaf.test.ts.snap
+++ b/test/serialize/__snapshots__/serialize-leaf.test.ts.snap
@@ -24,3 +24,23 @@ exports[`Serialize an italic paragraph from slate state to markdown 1`] = `
 "_italic paragraph_
 "
 `;
+
+exports[`Whitespace is retained when applying bold formatting 1`] = `
+"  **bold**  
+"
+`;
+
+exports[`Whitespace is retained when applying bold, italic and strikethrough formatting 1`] = `
+"  ~~***bold, italic, strikeThrough***~~  
+"
+`;
+
+exports[`Whitespace is retained when applying italic formatting 1`] = `
+"  _italic_  
+"
+`;
+
+exports[`Whitespace is retained when applying strikethrough formatting 1`] = `
+"  ~~strikeThrough~~  
+"
+`;

--- a/test/serialize/serialize-leaf.test.ts
+++ b/test/serialize/serialize-leaf.test.ts
@@ -72,3 +72,61 @@ it('Serialize a bold, italic and strikeThrough paragraph from slate state to mar
     })
   ).toMatchSnapshot();
 });
+
+it('Whitespace is retained when applying bold formatting', () => {
+  expect(
+    serialize({
+      type: defaultNodeTypes.paragraph,
+      children: [
+        {
+          bold: true,
+          text: '  bold  ',
+        },
+      ],
+    })
+  ).toMatchSnapshot();
+});
+
+it('Whitespace is retained when applying italic formatting', () => {
+  expect(
+    serialize({
+      type: defaultNodeTypes.paragraph,
+      children: [
+        {
+          italic: true,
+          text: '  italic  ',
+        },
+      ],
+    })
+  ).toMatchSnapshot();
+});
+
+it('Whitespace is retained when applying strikethrough formatting', () => {
+  expect(
+    serialize({
+      type: defaultNodeTypes.paragraph,
+      children: [
+        {
+          strikeThrough: true,
+          text: '  strikeThrough  ',
+        },
+      ],
+    })
+  ).toMatchSnapshot();
+});
+
+it('Whitespace is retained when applying bold, italic and strikethrough formatting', () => {
+  expect(
+    serialize({
+      type: defaultNodeTypes.paragraph,
+      children: [
+        {
+          strikeThrough: true,
+          bold: true,
+          italic: true,
+          text: '  bold, italic, strikeThrough  ',
+        },
+      ],
+    })
+  ).toMatchSnapshot();
+});


### PR DESCRIPTION
invoke retainWhitespaceandFormat when using strikeThrough format
handle bold, italic and strikeThrough formatting

fixes #19