### PR TITLE
fix typo, parapgraph -> paragraph

### DIFF
--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -115,7 +115,7 @@ export default function deserialize(
         };
       }
       // TODO: Handle other HTML?
-      return { type: 'parapgraph', children: [{ text: '' }] };
+      return { type: 'paragraph', children: [{ text: '' }] };
 
     case 'emphasis':
       return {

--- a/test/deserialize/__snapshots__/deserialize-content-with-html.test.ts.snap
+++ b/test/deserialize/__snapshots__/deserialize-content-with-html.test.ts.snap
@@ -31,6 +31,6 @@ Object {
       "text": "",
     },
   ],
-  "type": "parapgraph",
+  "type": "paragraph",
 }
 `;


### PR DESCRIPTION
I assume this is a typo and was not intentional. It was silently breaking parsing for me by creating a bunch of `parapgraph` elements. 

If it is intentional, perhaps a comment explaining that this is intentionally typoed.