### PR TITLE
fix module field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.2.2",
   "description": "remark plugin to compile Markdown to a slate compatible object",
   "license": "MIT",
-  "module": "dist/remark-slate-ts.esm.js",
+  "module": "dist/remark-slate.esm.js",
   "scripts": {
     "start": "tsdx watch",
     "build": "tsdx build",


### PR DESCRIPTION
It references `remark-slate-ts.esm.js` but the actual file is just [`remark-slate.esm.js`](https://unpkg.com/browse/remark-slate@1.2.2/dist/remark-slate.esm.js)