### PR TITLE
Add thematic break support

### DIFF
--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -17,6 +17,7 @@ export interface NodeTypes {
   emphasis_mark?: string;
   strong_mark?: string;
   delete_mark?: string;
+  thematic_break: string;
 }
 
 export interface OptionType {

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -60,7 +60,7 @@ export const defaultNodeTypes: NodeTypes = {
   emphasis_mark: 'italic',
   strong_mark: 'bold',
   delete_mark: 'strikeThrough',
-  thematic_break: 'thematicBreak',
+  thematic_break: 'thematic_break',
 };
 
 export default function deserialize(node: MdastNode, opts?: OptionType) {

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -59,6 +59,7 @@ export const defaultNodeTypes = {
   emphasis_mark: 'italic',
   strong_mark: 'bold',
   delete_mark: 'strikeThrough',
+  thematic_break: 'thematicBreak',
 };
 
 export default function deserialize(
@@ -143,6 +144,10 @@ export default function deserialize(
         [types.delete_mark]: true,
         ...forceLeafNode(children),
         ...persistLeafFormats(children),
+      };
+    case 'thematicBreak':
+      return {
+        [types.thematic_break]: true,
       };
 
     case 'text':

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -147,7 +147,8 @@ export default function deserialize(
       };
     case 'thematicBreak':
       return {
-        [types.thematic_break]: true,
+        type: types.thematic_break,
+        children: [{ text: '' }],
       };
 
     case 'text':

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -1,27 +1,27 @@
 export interface NodeTypes {
-  paragraph?: string;
-  block_quote?: string;
-  code_block?: string;
-  link?: string;
-  ul_list?: string;
-  ol_list?: string;
-  listItem?: string;
-  heading?: {
-    1?: string;
-    2?: string;
-    3?: string;
-    4?: string;
-    5?: string;
-    6?: string;
+  paragraph: string;
+  block_quote: string;
+  code_block: string;
+  link: string;
+  ul_list: string;
+  ol_list: string;
+  listItem: string;
+  heading: {
+    1: string;
+    2: string;
+    3: string;
+    4: string;
+    5: string;
+    6: string;
   };
-  emphasis_mark?: string;
-  strong_mark?: string;
-  delete_mark?: string;
+  emphasis_mark: string;
+  strong_mark: string;
+  delete_mark: string;
   thematic_break: string;
 }
 
 export interface OptionType {
-  nodeTypes?: NodeTypes;
+  nodeTypes?: Partial<NodeTypes>;
   linkDestinationKey?: string;
 }
 
@@ -41,7 +41,7 @@ export interface MdastNode {
   indent?: any;
 }
 
-export const defaultNodeTypes = {
+export const defaultNodeTypes: NodeTypes = {
   paragraph: 'paragraph',
   block_quote: 'block_quote',
   code_block: 'code_block',
@@ -63,20 +63,17 @@ export const defaultNodeTypes = {
   thematic_break: 'thematicBreak',
 };
 
-export default function deserialize(
-  node: MdastNode,
-  opts: OptionType = { nodeTypes: {} }
-) {
+export default function deserialize(node: MdastNode, opts?: OptionType) {
   const types = {
     ...defaultNodeTypes,
-    ...opts.nodeTypes,
+    ...opts?.nodeTypes,
     heading: {
       ...defaultNodeTypes.heading,
       ...opts?.nodeTypes?.heading,
     },
   };
 
-  const linkDestinationKey = opts.linkDestinationKey ?? 'link';
+  const linkDestinationKey = opts?.linkDestinationKey ?? 'link';
 
   let children = [{ text: '' }];
 

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -29,6 +29,8 @@ const isLeafNode = (node: BlockType | LeafType): node is LeafType => {
   return typeof (node as LeafType).text === 'string';
 };
 
+const VOID_ELEMENTS: Array<keyof NodeTypes> = ['thematic_break'];
+
 const BREAK_TAG = '<br>';
 
 export default function serialize(
@@ -124,7 +126,8 @@ export default function serialize(
     children = BREAK_TAG;
   }
 
-  if (children === '') return;
+  if (children === '' && !VOID_ELEMENTS.find((k) => nodeTypes[k] === type))
+    return;
 
   // Never allow decorating break tags with rich text formatting,
   // this can malform generated markdown

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -35,6 +35,9 @@ interface Options {
 const isTextLeafNode = (node: BlockType | LeafType): node is TextLeafType => {
   return typeof (node as TextLeafType).text === 'string';
 };
+const isEmptyLeafNode = (node: BlockType | LeafType): node is EmptyLeafType => {
+  return !!(node as EmptyLeafType).thematicBreak;
+};
 const isBlockNode = (node: BlockType | LeafType): node is BlockType => {
   return Array.isArray((node as BlockType).children);
 };
@@ -134,7 +137,7 @@ export default function serialize(
     children = BREAK_TAG;
   }
 
-  if (children === '') return;
+  if (children === '' && !isEmptyLeafNode(chunk)) return;
 
   // Never allow decorating break tags with rich text formatting,
   // this can malform generated markdown

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -212,6 +212,9 @@ export default function serialize(
     case nodeTypes.paragraph:
       return `${children}\n`;
 
+    case nodeTypes.thematic_break:
+      return `---\n`;
+
     default:
       return escapeHtml(children);
   }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -2,13 +2,20 @@ import escapeHtml from 'escape-html';
 
 import { defaultNodeTypes, NodeTypes } from './deserialize';
 
-export interface LeafType {
+interface TextLeafType {
   text: string;
   strikeThrough?: boolean;
   bold?: boolean;
   italic?: boolean;
   parentType?: string;
 }
+
+interface EmptyLeafType {
+  thematicBreak?: true;
+  parentType?: string;
+}
+
+export type LeafType = TextLeafType | EmptyLeafType;
 
 export interface BlockType {
   type: string;
@@ -41,7 +48,7 @@ export default function serialize(
     listDepth = 0,
   } = opts;
 
-  let text = (chunk as LeafType).text || '';
+  let text = (chunk as TextLeafType).text || '';
   let type = (chunk as BlockType).type || '';
 
   const nodeTypes = {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -44,7 +44,7 @@ export default function serialize(
   let text = (chunk as LeafType).text || '';
   let type = (chunk as BlockType).type || '';
 
-  const nodeTypes = {
+  const nodeTypes: NodeTypes = {
     ...defaultNodeTypes,
     ...userNodeTypes,
     heading: {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -124,7 +124,7 @@ export default function serialize(
     children = BREAK_TAG;
   }
 
-  if (children === '' && !isEmptyLeafNode(chunk)) return;
+  if (children === '') return;
 
   // Never allow decorating break tags with rich text formatting,
   // this can malform generated markdown

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -2,20 +2,13 @@ import escapeHtml from 'escape-html';
 
 import { defaultNodeTypes, NodeTypes } from './deserialize';
 
-interface TextLeafType {
+export interface LeafType {
   text: string;
   strikeThrough?: boolean;
   bold?: boolean;
   italic?: boolean;
   parentType?: string;
 }
-
-interface EmptyLeafType {
-  thematicBreak?: true;
-  parentType?: string;
-}
-
-export type LeafType = TextLeafType | EmptyLeafType;
 
 export interface BlockType {
   type: string;
@@ -48,7 +41,7 @@ export default function serialize(
     listDepth = 0,
   } = opts;
 
-  let text = (chunk as TextLeafType).text || '';
+  let text = (chunk as LeafType).text || '';
   let type = (chunk as BlockType).type || '';
 
   const nodeTypes = {

--- a/test/deserialize/__snapshots__/thematicBreak.test.ts.snap
+++ b/test/deserialize/__snapshots__/thematicBreak.test.ts.snap
@@ -3,7 +3,12 @@
 exports[`When the list has thematic breaks 1`] = `
 Array [
   Object {
-    "thematicBreak": true,
+    "children": Array [
+      Object {
+        "text": "",
+      },
+    ],
+    "type": "thematicBreak",
   },
   Object {
     "children": Array [

--- a/test/deserialize/__snapshots__/thematicBreak.test.ts.snap
+++ b/test/deserialize/__snapshots__/thematicBreak.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`When the list has thematic breaks 1`] = `
 Array [
   Object {
-    "text": "",
+    "thematicBreak": true,
   },
   Object {
     "children": Array [

--- a/test/deserialize/__snapshots__/thematicBreak.test.ts.snap
+++ b/test/deserialize/__snapshots__/thematicBreak.test.ts.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`When the list has thematic breaks 1`] = `
+Array [
+  Object {
+    "text": "",
+  },
+  Object {
+    "children": Array [
+      Object {
+        "text": "foo",
+      },
+    ],
+    "type": "paragraph",
+  },
+]
+`;

--- a/test/deserialize/thematicBreak.test.ts
+++ b/test/deserialize/thematicBreak.test.ts
@@ -1,0 +1,8 @@
+import { deserialize } from '../../src';
+import thematicBreakast from '../fixtures/thematic-break';
+
+it('When the list has thematic breaks', () => {
+  expect(
+    thematicBreakast.children.map((k) => deserialize(k))
+  ).toMatchSnapshot();
+});

--- a/test/fixtures/thematic-break.ts
+++ b/test/fixtures/thematic-break.ts
@@ -1,0 +1,29 @@
+export default {
+  type: 'root',
+  children: [
+    {
+      type: 'thematicBreak',
+      position: {
+        start: { line: 1, column: 1, offset: 0 },
+        end: { line: 1, column: 4, offset: 3 },
+      },
+    },
+    {
+      type: 'paragraph',
+      children: [
+        {
+          type: 'text',
+          value: 'foo',
+          position: {
+            start: { line: 2, column: 1, offset: 4 },
+            end: { line: 2, column: 4, offset: 7 },
+          },
+        },
+      ],
+      position: {
+        start: { line: 2, column: 1, offset: 4 },
+        end: { line: 2, column: 4, offset: 7 },
+      },
+    },
+  ],
+};

--- a/test/serialize/__snapshots__/serialize-thematic-break.test.ts.snap
+++ b/test/serialize/__snapshots__/serialize-thematic-break.test.ts.snap
@@ -1,0 +1,6 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Serialize a heading one from slate state to markdown 1`] = `
+"---
+"
+`;

--- a/test/serialize/serialize-thematic-break.test.ts
+++ b/test/serialize/serialize-thematic-break.test.ts
@@ -1,0 +1,10 @@
+import { serialize, defaultNodeTypes } from '../../src';
+
+it('Serialize a heading one from slate state to markdown', () => {
+  expect(
+    serialize({
+      type: defaultNodeTypes.thematic_break,
+      thematicBreak: true,
+    })
+  ).toMatchSnapshot();
+});

--- a/test/serialize/serialize-thematic-break.test.ts
+++ b/test/serialize/serialize-thematic-break.test.ts
@@ -4,7 +4,7 @@ it('Serialize a heading one from slate state to markdown', () => {
   expect(
     serialize({
       type: defaultNodeTypes.thematic_break,
-      thematicBreak: true,
+      children: [{ text: '' }],
     })
   ).toMatchSnapshot();
 });

--- a/test/serialize/serialize-thematic-break.test.ts
+++ b/test/serialize/serialize-thematic-break.test.ts
@@ -1,6 +1,6 @@
 import { serialize, defaultNodeTypes } from '../../src';
 
-it('Serialize a heading one from slate state to markdown', () => {
+it('Serialize a thematic break from slate state to markdown', () => {
   expect(
     serialize({
       type: defaultNodeTypes.thematic_break,


### PR DESCRIPTION
Issue: library does not support [thematic break elements](https://github.com/syntax-tree/mdast#thematicbreak).

This PR adds the functionality, with tests for serialization/deserialization.

The changes were pretty straightforward -- some complexity came from the assumption that a Leaf node will always have `text` that acts as its `children` property.

Split the leaf type out into a union type and added more type guards to choose the correct behavior.
There are probably other ways to do this, but IMO verbose typeguards aren't a bad thing. The `Array.isArray(node.children)` check was already happening anyway.