### PR TITLE
Preserve html nodes as text

### DIFF
--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -126,8 +126,7 @@ export default function deserialize(node: MdastNode, opts?: OptionType) {
           children: [{ text: node.value?.replace(/<br>/g, '') || '' }],
         };
       }
-      // TODO: Handle other HTML?
-      return { type: 'paragraph', children: [{ text: '' }] };
+      return { type: 'paragraph', children: [{ text: node.value || '' }] };
 
     case 'emphasis':
       return {

--- a/test/deserialize/__snapshots__/deserialize-content-with-html.test.ts.snap
+++ b/test/deserialize/__snapshots__/deserialize-content-with-html.test.ts.snap
@@ -28,7 +28,7 @@ exports[`deserialize unknown html 1`] = `
 Object {
   "children": Array [
     Object {
-      "text": "",
+      "text": "<section>",
     },
   ],
   "type": "paragraph",


### PR DESCRIPTION
I think this as a default makes more sense - we had to dig into why the whole particular input string has vanished completely and why it couldn't be rendered.

It seems to me that any transformations on `html` should be pluggable as in some cases it might actually be required for this part to be preserved. I haven't thought about this problem space long enough though - would first need to figure out what kind of HTML could/should be normalized to Slate nodes.