### PR TITLE
implement images (#6)

### DIFF
--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -3,6 +3,7 @@ export interface NodeTypes {
   block_quote: string;
   code_block: string;
   link: string;
+  image: string;
   ul_list: string;
   ol_list: string;
   listItem: string;
@@ -27,6 +28,8 @@ type RecursivePartial<T> = {
 export interface OptionType {
   nodeTypes?: RecursivePartial<NodeTypes>;
   linkDestinationKey?: string;
+  imageSourceKey?: string;
+  imageCaptionKey?: string;
 }
 
 export interface MdastNode {
@@ -37,6 +40,7 @@ export interface MdastNode {
   children?: Array<MdastNode>;
   depth?: 1 | 2 | 3 | 4 | 5 | 6;
   url?: string;
+  alt?: string;
   lang?: string;
   // mdast metadata
   position?: any;
@@ -65,6 +69,7 @@ export const defaultNodeTypes: NodeTypes = {
   strong_mark: 'bold',
   delete_mark: 'strikeThrough',
   thematic_break: 'thematic_break',
+  image: 'image',
 };
 
 export default function deserialize(node: MdastNode, opts?: OptionType) {
@@ -78,6 +83,8 @@ export default function deserialize(node: MdastNode, opts?: OptionType) {
   };
 
   const linkDestinationKey = opts?.linkDestinationKey ?? 'link';
+  const imageSourceKey = opts?.imageSourceKey ?? 'link';
+  const imageCaptionKey = opts?.imageCaptionKey ?? 'caption';
 
   let children = [{ text: '' }];
 
@@ -109,6 +116,13 @@ export default function deserialize(node: MdastNode, opts?: OptionType) {
       return { type: types.paragraph, children };
     case 'link':
       return { type: types.link, [linkDestinationKey]: node.url, children };
+    case 'image':
+      return {
+        type: types.image,
+        children: [{ text: '' }],
+        [imageSourceKey]: node.url,
+        [imageCaptionKey]: node.alt,
+      };
     case 'blockquote':
       return { type: types.block_quote, children };
     case 'code':

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -185,7 +185,9 @@ export default function serialize(
     case nodeTypes.link:
       return `[${children}](${(chunk as BlockType).link || ''})`;
     case nodeTypes.image:
-      return `![${(chunk as BlockType).caption}](${(chunk as BlockType).link || ''})`;
+      return `![${(chunk as BlockType).caption}](${
+        (chunk as BlockType).link || ''
+      })`;
 
     case nodeTypes.ul_list:
     case nodeTypes.ol_list:

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -14,6 +14,7 @@ export interface BlockType {
   type: string;
   parentType?: string;
   link?: string;
+  caption?: string;
   language?: string;
   break?: boolean;
   children: Array<BlockType | LeafType>;
@@ -183,6 +184,8 @@ export default function serialize(
 
     case nodeTypes.link:
       return `[${children}](${(chunk as BlockType).link || ''})`;
+    case nodeTypes.image:
+      return `![${(chunk as BlockType).caption}](${(chunk as BlockType).link || ''})`;
 
     case nodeTypes.ul_list:
     case nodeTypes.ol_list:

--- a/test/deserialize/__snapshots__/image.test.ts.snap
+++ b/test/deserialize/__snapshots__/image.test.ts.snap
@@ -2,12 +2,13 @@
 
 exports[`deserialize image 1`] = `
 Object {
+  "caption": "'Jack's profile picture'",
   "children": Array [
     Object {
       "text": "",
     },
   ],
-  "link": "https://www.samsonzhang.com/img/about.jpg",
+  "link": "https://avatars.githubusercontent.com/u/2148168",
   "type": "image",
 }
 `;

--- a/test/deserialize/__snapshots__/image.test.ts.snap
+++ b/test/deserialize/__snapshots__/image.test.ts.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`deserialize image 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "text": "",
+    },
+  ],
+  "link": "https://www.samsonzhang.com/img/about.jpg",
+  "type": "image",
+}
+`;

--- a/test/deserialize/image.test.ts
+++ b/test/deserialize/image.test.ts
@@ -5,7 +5,7 @@ it('deserialize image', () => {
     deserialize({
       type: 'image',
       url: 'https://avatars.githubusercontent.com/u/2148168',
-      alt: 'Jack\'s profile picture',
+      alt: "'Jack's profile picture'",
       children: [{ text: '' }],
     })
   ).toMatchSnapshot();

--- a/test/deserialize/image.test.ts
+++ b/test/deserialize/image.test.ts
@@ -1,0 +1,12 @@
+import { deserialize } from '../../src';
+
+it('deserialize image', () => {
+  expect(
+    deserialize({
+      type: 'image',
+      url: 'https://avatars.githubusercontent.com/u/2148168',
+      alt: 'Jack\'s profile picture',
+      children: [{ text: '' }],
+    })
+  ).toMatchSnapshot();
+});

--- a/test/example.md
+++ b/test/example.md
@@ -12,6 +12,8 @@ Slate is interesting, hopefully it'll work better than react-rte so we can have 
 - Kiwi
 - Strawberry
 
+![Jack's profile picture](https://avatars.githubusercontent.com/u/2148168)
+
 Check out [my website](https://jackhanford.com)
 
 > Always bet on javascript

--- a/test/serialize/__snapshots__/serialize-image.test.ts.snap
+++ b/test/serialize/__snapshots__/serialize-image.test.ts.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Serialize a image from slate state to markdown 1`] = `undefined`;

--- a/test/serialize/serialize-image.test.ts
+++ b/test/serialize/serialize-image.test.ts
@@ -5,7 +5,7 @@ it('Serialize a image from slate state to markdown', () => {
     serialize({
       type: defaultNodeTypes.image,
       link: 'https://avatars.githubusercontent.com/u/2148168',
-      caption: 'Jack\'s profile picture',
+      caption: "'Jack's profile picture'",
       children: [],
     })
   ).toMatchSnapshot();

--- a/test/serialize/serialize-image.test.ts
+++ b/test/serialize/serialize-image.test.ts
@@ -1,0 +1,12 @@
+import { serialize, defaultNodeTypes } from '../../src';
+
+it('Serialize a image from slate state to markdown', () => {
+  expect(
+    serialize({
+      type: defaultNodeTypes.image,
+      link: 'https://avatars.githubusercontent.com/u/2148168',
+      caption: 'Jack\'s profile picture',
+      children: [],
+    })
+  ).toMatchSnapshot();
+});


### PR DESCRIPTION
Addresses #6 

- add `image` to `NodeTypes`
- add `imageSourceKey` and `imageCaptionKey` to `OptionType`
- add `alt` to `MdastNode`
- add image to serializer and deserializer
- add `image.test.ts` and `serialize-image.test.ts` tests along with snapshots