### PR TITLE
add support for inline code

### DIFF
--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -17,6 +17,7 @@ export interface NodeTypes {
   emphasis_mark: string;
   strong_mark: string;
   delete_mark: string;
+  inline_code_mark: string;
   thematic_break: string;
 }
 
@@ -64,6 +65,7 @@ export const defaultNodeTypes: NodeTypes = {
   emphasis_mark: 'italic',
   strong_mark: 'bold',
   delete_mark: 'strikeThrough',
+  inline_code_mark: 'code',
   thematic_break: 'thematic_break',
 };
 
@@ -144,6 +146,12 @@ export default function deserialize(node: MdastNode, opts?: OptionType) {
       return {
         [types.delete_mark]: true,
         ...forceLeafNode(children),
+        ...persistLeafFormats(children),
+      };
+    case 'inlineCode':
+      return {
+        [types.inline_code_mark]: true,
+        text: node.value,
         ...persistLeafFormats(children),
       };
     case 'thematicBreak':

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -7,6 +7,7 @@ export interface LeafType {
   strikeThrough?: boolean;
   bold?: boolean;
   italic?: boolean;
+  code?: boolean;
   parentType?: string;
 }
 
@@ -152,6 +153,10 @@ export default function serialize(
 
       if (chunk.strikeThrough) {
         children = retainWhitespaceAndFormat(children, '~~');
+      }
+
+      if (chunk.code) {
+        children = retainWhitespaceAndFormat(children, '`');
       }
     }
   }

--- a/test/deserialize/__snapshots__/leafNodes.test.ts.snap
+++ b/test/deserialize/__snapshots__/leafNodes.test.ts.snap
@@ -52,6 +52,18 @@ Object {
 }
 `;
 
+exports[`Deserialize a leaf node with inline code directly inline 1`] = `
+Object {
+  "children": Array [
+    Object {
+      "code": true,
+      "text": "inline code",
+    },
+  ],
+  "type": "paragraph",
+}
+`;
+
 exports[`Deserialize a leaf node with just bold 1`] = `
 Object {
   "children": Array [

--- a/test/deserialize/leafNodes.test.ts
+++ b/test/deserialize/leafNodes.test.ts
@@ -146,6 +146,20 @@ it('Deserialize a leaf node with just strikethrough', () => {
   ).toMatchSnapshot();
 });
 
+it('Deserialize a leaf node with inline code directly inline', () => {
+  expect(
+    deserialize({
+      type: 'paragraph',
+      children: [
+        {
+          type: 'inlineCode',
+          value: 'inline code',
+        },
+      ],
+    })
+  ).toMatchSnapshot();
+});
+
 it('Handles cases where leafs have metadata attached', () => {
   expect(
     deserialize({

--- a/test/example.md
+++ b/test/example.md
@@ -2,7 +2,7 @@
 
 ## Slate POC
 
-Slate is interesting, hopefully it'll work better than react-rte so we can have a better text editor. Some of the _benefits_ of slate are:
+Slate is interesting, hopefully it'll work better than `react-rte` so we can have a better text editor. Some of the _benefits_ of slate are:
 
 1. Total control over how everything works
 1. Near AST level API where you can control the editor / content

--- a/test/serialize/__snapshots__/serialize-leaf.test.ts.snap
+++ b/test/serialize/__snapshots__/serialize-leaf.test.ts.snap
@@ -15,6 +15,11 @@ exports[`Serialize a bold, italic and strikeThrough paragraph from slate state t
 "
 `;
 
+exports[`Serialize a code paragraph from slate state to markdown 1`] = `
+"\`inline code paragraph\`
+"
+`;
+
 exports[`Serialize a strikeThrough paragraph from slate state to markdown 1`] = `
 "~~strikeThrough paragraph~~
 "

--- a/test/serialize/serialize-leaf.test.ts
+++ b/test/serialize/serialize-leaf.test.ts
@@ -42,6 +42,20 @@ it('Serialize a strikeThrough paragraph from slate state to markdown', () => {
   ).toMatchSnapshot();
 });
 
+it('Serialize a code paragraph from slate state to markdown', () => {
+  expect(
+    serialize({
+      type: defaultNodeTypes.paragraph,
+      children: [
+        {
+          code: true,
+          text: 'inline code paragraph',
+        },
+      ],
+    })
+  ).toMatchSnapshot();
+});
+
 it('Serialize a bold and italic paragraph from slate state to markdown', () => {
   expect(
     serialize({


### PR DESCRIPTION
addresses #30 
- add `inline_code_mark` to `NodeTypes` with `code` as default
- add `code` to `LeafType`
- add serialization and deserialization code
- add tests and snapshots