### PR TITLE
Add image to VOID_ELEMENTS

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -31,7 +31,7 @@ const isLeafNode = (node: BlockType | LeafType): node is LeafType => {
   return typeof (node as LeafType).text === 'string';
 };
 
-const VOID_ELEMENTS: Array<keyof NodeTypes> = ['thematic_break'];
+const VOID_ELEMENTS: Array<keyof NodeTypes> = ['thematic_break', 'image'];
 
 const BREAK_TAG = '<br>';
 

--- a/test/serialize/__snapshots__/serialize-image.test.ts.snap
+++ b/test/serialize/__snapshots__/serialize-image.test.ts.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Serialize a image from slate state to markdown 1`] = `undefined`;
+exports[`Serialize a image from slate state to markdown 1`] = `"!['Jack's profile picture'](https://avatars.githubusercontent.com/u/2148168)"`;


### PR DESCRIPTION
Hi, I had a problem with the serialization of image.

Slate need the `children: [{text: ""}]` but the serialization ignores non-void elements with empty children which makes image disappear at the end.

Test are updated