### PR TITLE
Update deserialize to use a flatMap instead of map

### DIFF
--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -96,7 +96,7 @@ export default function deserialize(node: MdastNode, opts?: OptionType) {
     node.children.length > 0
   ) {
     // @ts-ignore
-    children = node.children.map((c: MdastNode) =>
+    children = node.children.flatMap((c: MdastNode) =>
       deserialize(
         {
           ...c,


### PR DESCRIPTION
Switching from a map to a flatMap makes it possible to provide an array of elements instead of a single element for the return of the switch statement. This is useful if you want to add an empty text element before/after an image element, or replace a simple node with a more complex tree.