### PR TITLE
Declare NodeTypes as const strings to support tagged unions

### DIFF
--- a/src/ast-types.ts
+++ b/src/ast-types.ts
@@ -1,0 +1,83 @@
+export interface NodeTypes {
+  paragraph: 'paragraph';
+  block_quote: 'block_quote';
+  code_block: 'code_block';
+  link: 'link';
+  ul_list: 'ul_list';
+  ol_list: 'ol_list';
+  listItem: 'list_item';
+  heading: {
+    1: 'heading_one';
+    2: 'heading_two';
+    3: 'heading_three';
+    4: 'heading_four';
+    5: 'heading_five';
+    6: 'heading_six';
+  };
+  emphasis_mark: 'italic';
+  strong_mark: 'bold';
+  delete_mark: 'strikeThrough';
+  inline_code_mark: 'code';
+  thematic_break: 'thematic_break';
+  image: 'image';
+}
+
+export type MdastNodeType =
+  | 'paragraph'
+  | 'heading'
+  | 'list'
+  | 'listItem'
+  | 'link'
+  | 'image'
+  | 'blockquote'
+  | 'code'
+  | 'html'
+  | 'emphasis'
+  | 'strong'
+  | 'delete'
+  | 'inlineCode'
+  | 'thematicBreak'
+  | 'text';
+
+export const defaultNodeTypes: NodeTypes = {
+  paragraph: 'paragraph',
+  block_quote: 'block_quote',
+  code_block: 'code_block',
+  link: 'link',
+  ul_list: 'ul_list',
+  ol_list: 'ol_list',
+  listItem: 'list_item',
+  heading: {
+    1: 'heading_one',
+    2: 'heading_two',
+    3: 'heading_three',
+    4: 'heading_four',
+    5: 'heading_five',
+    6: 'heading_six',
+  },
+  emphasis_mark: 'italic',
+  strong_mark: 'bold',
+  delete_mark: 'strikeThrough',
+  inline_code_mark: 'code',
+  thematic_break: 'thematic_break',
+  image: 'image',
+};
+
+export interface LeafType {
+  text: string;
+  strikeThrough?: boolean;
+  bold?: boolean;
+  italic?: boolean;
+  code?: boolean;
+  parentType?: string;
+}
+
+export interface BlockType {
+  type: string;
+  parentType?: string;
+  link?: string;
+  caption?: string;
+  language?: string;
+  break?: boolean;
+  children: Array<BlockType | LeafType>;
+}

--- a/src/ast-types.ts
+++ b/src/ast-types.ts
@@ -81,3 +81,156 @@ export interface BlockType {
   break?: boolean;
   children: Array<BlockType | LeafType>;
 }
+
+export interface InputNodeTypes {
+  paragraph: string;
+  block_quote: string;
+  code_block: string;
+  link: string;
+  ul_list: string;
+  ol_list: string;
+  listItem: string;
+  heading: {
+    1: string;
+    2: string;
+    3: string;
+    4: string;
+    5: string;
+    6: string;
+  };
+  emphasis_mark: string;
+  strong_mark: string;
+  delete_mark: string;
+  inline_code_mark: string;
+  thematic_break: string;
+  image: string;
+}
+
+type RecursivePartial<T> = {
+  [P in keyof T]?: RecursivePartial<T[P]>;
+};
+
+export interface OptionType<T extends InputNodeTypes = InputNodeTypes> {
+  nodeTypes?: RecursivePartial<T>;
+  linkDestinationKey?: string;
+  imageSourceKey?: string;
+  imageCaptionKey?: string;
+}
+
+export interface MdastNode {
+  type?: MdastNodeType;
+  ordered?: boolean;
+  value?: string;
+  text?: string;
+  children?: Array<MdastNode>;
+  depth?: 1 | 2 | 3 | 4 | 5 | 6;
+  url?: string;
+  alt?: string;
+  lang?: string;
+  // mdast metadata
+  position?: any;
+  spread?: any;
+  checked?: any;
+  indent?: any;
+}
+
+export type TextNode = { text?: string | undefined };
+
+export type CodeBlockNode<T extends InputNodeTypes> = {
+  type: T['code_block'];
+  language: string | undefined;
+  children: Array<TextNode>;
+};
+
+export type HeadingNode<T extends InputNodeTypes> = {
+  type:
+    | T['heading'][1]
+    | T['heading'][2]
+    | T['heading'][3]
+    | T['heading'][4]
+    | T['heading'][5]
+    | T['heading'][6];
+  children: Array<DeserializedNode<T>>;
+};
+
+export type ListNode<T extends InputNodeTypes> = {
+  type: T['ol_list'] | T['ul_list'];
+  children: Array<DeserializedNode<T>>;
+};
+
+export type ListItemNode<T extends InputNodeTypes> = {
+  type: T['listItem'];
+  children: Array<DeserializedNode<T>>;
+};
+
+export type ParagraphNode<T extends InputNodeTypes> = {
+  type: T['paragraph'];
+  break?: true;
+  children: Array<DeserializedNode<T>>;
+};
+
+export type LinkNode<T extends InputNodeTypes> = {
+  type: T['link'];
+  children: Array<DeserializedNode<T>>;
+  [urlKey: string]: string | undefined | Array<DeserializedNode<T>>;
+};
+
+export type ImageNode<T extends InputNodeTypes> = {
+  type: T['image'];
+  children: Array<DeserializedNode<T>>;
+  [sourceOrCaptionKey: string]: string | undefined | Array<DeserializedNode<T>>;
+};
+
+export type BlockQuoteNode<T extends InputNodeTypes> = {
+  type: T['block_quote'];
+  children: Array<DeserializedNode<T>>;
+};
+
+export type InlineCodeMarkNode<T extends InputNodeTypes> = {
+  type: T['inline_code_mark'];
+  children: Array<TextNode>;
+  language: string | undefined;
+};
+
+export type ThematicBreakNode<T extends InputNodeTypes> = {
+  type: T['thematic_break'];
+  children: Array<DeserializedNode<T>>;
+};
+
+export type ItalicNode<T extends InputNodeTypes> = {
+  [K in T['emphasis_mark']]: true;
+} & {
+  children: TextNode;
+};
+
+export type BoldNode = {
+  bold: true;
+  children: TextNode;
+};
+
+export type StrikeThoughNode = {
+  strikeThrough: true;
+  children: TextNode;
+};
+
+export type InlineCodeNode = {
+  code: true;
+  text: string | undefined;
+};
+
+export type DeserializedNode<T extends InputNodeTypes> =
+  | CodeBlockNode<T>
+  | HeadingNode<T>
+  | ListNode<T>
+  | ListItemNode<T>
+  | ParagraphNode<T>
+  | LinkNode<T>
+  | ImageNode<T>
+  | BlockQuoteNode<T>
+  | InlineCodeMarkNode<T>
+  | ThematicBreakNode<T>
+  | ItalicNode<T>
+  | BoldNode
+  | StrikeThoughNode
+  | InlineCodeNode
+  | TextNode;

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -1,25 +1,25 @@
 export interface NodeTypes {
-  paragraph: string;
-  block_quote: string;
-  code_block: string;
-  link: string;
-  image: string;
-  ul_list: string;
-  ol_list: string;
-  listItem: string;
+  paragraph: 'paragraph'
+  block_quote: 'block_quote'
+  code_block: 'code_block'
+  link: 'link'
+  ul_list: 'ul_list'
+  ol_list: 'ol_list'
+  listItem: 'list_item'
   heading: {
-    1: string;
-    2: string;
-    3: string;
-    4: string;
-    5: string;
-    6: string;
-  };
-  emphasis_mark: string;
-  strong_mark: string;
-  delete_mark: string;
-  inline_code_mark: string;
-  thematic_break: string;
+    1: 'heading_one'
+    2: 'heading_two'
+    3: 'heading_three'
+    4: 'heading_four'
+    5: 'heading_five'
+    6: 'heading_six'
+  }
+  emphasis_mark: 'italic'
+  strong_mark: 'bold'
+  delete_mark: 'strikeThrough'
+  inline_code_mark: 'code'
+  thematic_break: 'thematic_break'
+  image: 'image'
 }
 
 type RecursivePartial<T> = {

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -1,25 +1,25 @@
 export interface NodeTypes {
-  paragraph: 'paragraph'
-  block_quote: 'block_quote'
-  code_block: 'code_block'
-  link: 'link'
-  ul_list: 'ul_list'
-  ol_list: 'ol_list'
-  listItem: 'list_item'
+  paragraph: 'paragraph';
+  block_quote: 'block_quote';
+  code_block: 'code_block';
+  link: 'link';
+  ul_list: 'ul_list';
+  ol_list: 'ol_list';
+  listItem: 'list_item';
   heading: {
-    1: 'heading_one'
-    2: 'heading_two'
-    3: 'heading_three'
-    4: 'heading_four'
-    5: 'heading_five'
-    6: 'heading_six'
-  }
-  emphasis_mark: 'italic'
-  strong_mark: 'bold'
-  delete_mark: 'strikeThrough'
-  inline_code_mark: 'code'
-  thematic_break: 'thematic_break'
-  image: 'image'
+    1: 'heading_one';
+    2: 'heading_two';
+    3: 'heading_three';
+    4: 'heading_four';
+    5: 'heading_five';
+    6: 'heading_six';
+  };
+  emphasis_mark: 'italic';
+  strong_mark: 'bold';
+  delete_mark: 'strikeThrough';
+  inline_code_mark: 'code';
+  thematic_break: 'thematic_break';
+  image: 'image';
 }
 
 type RecursivePartial<T> = {

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -1,3 +1,5 @@
+import { defaultNodeTypes, MdastNodeType } from './ast-types';
+
 export interface InputNodeTypes {
   paragraph: string;
   block_quote: string;
@@ -21,57 +23,17 @@ export interface InputNodeTypes {
   thematic_break: string;
   image: string;
 }
-export interface NodeTypes {
-  paragraph: 'paragraph';
-  block_quote: 'block_quote';
-  code_block: 'code_block';
-  link: 'link';
-  ul_list: 'ul_list';
-  ol_list: 'ol_list';
-  listItem: 'list_item';
-  heading: {
-    1: 'heading_one';
-    2: 'heading_two';
-    3: 'heading_three';
-    4: 'heading_four';
-    5: 'heading_five';
-    6: 'heading_six';
-  };
-  emphasis_mark: 'italic';
-  strong_mark: 'bold';
-  delete_mark: 'strikeThrough';
-  inline_code_mark: 'code';
-  thematic_break: 'thematic_break';
-  image: 'image';
-}
 
 type RecursivePartial<T> = {
   [P in keyof T]?: RecursivePartial<T[P]>;
 };
 
-export interface OptionType<T extends InputNodeTypes> {
+export interface OptionType<T extends InputNodeTypes = InputNodeTypes> {
   nodeTypes?: RecursivePartial<T>;
   linkDestinationKey?: string;
   imageSourceKey?: string;
   imageCaptionKey?: string;
 }
-
-export type MdastNodeType =
-  | 'paragraph'
-  | 'heading'
-  | 'list'
-  | 'listItem'
-  | 'link'
-  | 'image'
-  | 'blockquote'
-  | 'code'
-  | 'html'
-  | 'emphasis'
-  | 'strong'
-  | 'delete'
-  | 'inlineCode'
-  | 'thematicBreak'
-  | 'text';
 
 export interface MdastNode {
   type?: MdastNodeType;
@@ -89,30 +51,6 @@ export interface MdastNode {
   checked?: any;
   indent?: any;
 }
-
-export const defaultNodeTypes: NodeTypes = {
-  paragraph: 'paragraph',
-  block_quote: 'block_quote',
-  code_block: 'code_block',
-  link: 'link',
-  ul_list: 'ul_list',
-  ol_list: 'ol_list',
-  listItem: 'list_item',
-  heading: {
-    1: 'heading_one',
-    2: 'heading_two',
-    3: 'heading_three',
-    4: 'heading_four',
-    5: 'heading_five',
-    6: 'heading_six',
-  },
-  emphasis_mark: 'italic',
-  strong_mark: 'bold',
-  delete_mark: 'strikeThrough',
-  inline_code_mark: 'code',
-  thematic_break: 'thematic_break',
-  image: 'image',
-};
 
 type TextNode = { text?: string | undefined };
 

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -56,8 +56,25 @@ export interface OptionType<T extends InputNodeTypes> {
   imageCaptionKey?: string;
 }
 
+export type MdastNodeType =
+  | 'paragraph'
+  | 'heading'
+  | 'list'
+  | 'listItem'
+  | 'link'
+  | 'image'
+  | 'blockquote'
+  | 'code'
+  | 'html'
+  | 'emphasis'
+  | 'strong'
+  | 'delete'
+  | 'inlineCode'
+  | 'thematicBreak'
+  | 'text';
+
 export interface MdastNode {
-  type?: string;
+  type?: MdastNodeType;
   ordered?: boolean;
   value?: string;
   text?: string;
@@ -198,7 +215,7 @@ export type DeserializedNode<T extends InputNodeTypes> =
   | InlineCodeNode
   | TextNode;
 
-export default function deserialize<T extends InputNodeTypes = NodeTypes>(
+export default function deserialize<T extends InputNodeTypes>(
   node: MdastNode,
   opts?: OptionType<T>
 ) {

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -1,157 +1,21 @@
-import { defaultNodeTypes, MdastNodeType } from './ast-types';
-
-export interface InputNodeTypes {
-  paragraph: string;
-  block_quote: string;
-  code_block: string;
-  link: string;
-  ul_list: string;
-  ol_list: string;
-  listItem: string;
-  heading: {
-    1: string;
-    2: string;
-    3: string;
-    4: string;
-    5: string;
-    6: string;
-  };
-  emphasis_mark: string;
-  strong_mark: string;
-  delete_mark: string;
-  inline_code_mark: string;
-  thematic_break: string;
-  image: string;
-}
-
-type RecursivePartial<T> = {
-  [P in keyof T]?: RecursivePartial<T[P]>;
-};
-
-export interface OptionType<T extends InputNodeTypes = InputNodeTypes> {
-  nodeTypes?: RecursivePartial<T>;
-  linkDestinationKey?: string;
-  imageSourceKey?: string;
-  imageCaptionKey?: string;
-}
-
-export interface MdastNode {
-  type?: MdastNodeType;
-  ordered?: boolean;
-  value?: string;
-  text?: string;
-  children?: Array<MdastNode>;
-  depth?: 1 | 2 | 3 | 4 | 5 | 6;
-  url?: string;
-  alt?: string;
-  lang?: string;
-  // mdast metadata
-  position?: any;
-  spread?: any;
-  checked?: any;
-  indent?: any;
-}
-
-type TextNode = { text?: string | undefined };
-
-type CodeBlockNode<T extends InputNodeTypes> = {
-  type: T['code_block'];
-  language: string | undefined;
-  children: Array<TextNode>;
-};
-
-type HeadingNode<T extends InputNodeTypes> = {
-  type:
-    | T['heading'][1]
-    | T['heading'][2]
-    | T['heading'][3]
-    | T['heading'][4]
-    | T['heading'][5]
-    | T['heading'][6];
-  children: Array<DeserializedNode<T>>;
-};
-
-type ListNode<T extends InputNodeTypes> = {
-  type: T['ol_list'] | T['ul_list'];
-  children: Array<DeserializedNode<T>>;
-};
-
-type ListItemNode<T extends InputNodeTypes> = {
-  type: T['listItem'];
-  children: Array<DeserializedNode<T>>;
-};
-
-type ParagraphNode<T extends InputNodeTypes> = {
-  type: T['paragraph'];
-  break?: true;
-  children: Array<DeserializedNode<T>>;
-};
-
-type LinkNode<T extends InputNodeTypes> = {
-  type: T['link'];
-  children: Array<DeserializedNode<T>>;
-  [urlKey: string]: string | undefined | Array<DeserializedNode<T>>;
-};
-
-type ImageNode<T extends InputNodeTypes> = {
-  type: T['image'];
-  children: Array<DeserializedNode<T>>;
-  [sourceOrCaptionKey: string]: string | undefined | Array<DeserializedNode<T>>;
-};
-
-type BlockQuoteNode<T extends InputNodeTypes> = {
-  type: T['block_quote'];
-  children: Array<DeserializedNode<T>>;
-};
-
-type InlineCodeMarkNode<T extends InputNodeTypes> = {
-  type: T['inline_code_mark'];
-  children: Array<TextNode>;
-  language: string | undefined;
-};
-
-type ThematicBreakNode<T extends InputNodeTypes> = {
-  type: T['thematic_break'];
-  children: Array<DeserializedNode<T>>;
-};
-
-type ItalicNode<T extends InputNodeTypes> = {
-  [K in T['emphasis_mark']]: true;
-} & {
-  children: TextNode;
-};
-
-type BoldNode = {
-  bold: true;
-  children: TextNode;
-};
-
-type StrikeThoughNode = {
-  strikeThrough: true;
-  children: TextNode;
-};
-
-type InlineCodeNode = {
-  code: true;
-  text: string | undefined;
-};
-
-export type DeserializedNode<T extends InputNodeTypes> =
-  | CodeBlockNode<T>
-  | HeadingNode<T>
-  | ListNode<T>
-  | ListItemNode<T>
-  | ParagraphNode<T>
-  | LinkNode<T>
-  | ImageNode<T>
-  | BlockQuoteNode<T>
-  | InlineCodeMarkNode<T>
-  | ThematicBreakNode<T>
-  | ItalicNode<T>
-  | BoldNode
-  | StrikeThoughNode
-  | InlineCodeNode
-  | TextNode;
+import {
+  BlockQuoteNode,
+  CodeBlockNode,
+  defaultNodeTypes,
+  DeserializedNode,
+  HeadingNode,
+  ImageNode,
+  InputNodeTypes,
+  ItalicNode,
+  LinkNode,
+  ListItemNode,
+  ListNode,
+  MdastNode,
+  OptionType,
+  ParagraphNode,
+  TextNode,
+  ThematicBreakNode,
+} from './ast-types';
 
 export default function deserialize<T extends InputNodeTypes>(
   node: MdastNode,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
-import deserialize, { defaultNodeTypes } from './deserialize';
+import deserialize from './deserialize';
 import serialize from './serialize';
 import plugin from './plugin';
 
-export { deserialize, serialize, defaultNodeTypes };
+export * from './ast-types';
+
+export { deserialize, serialize };
 
 export default plugin;

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -1,4 +1,5 @@
-import transform, { OptionType, MdastNode } from './deserialize';
+import { MdastNode, OptionType } from './ast-types';
+import transform from './deserialize';
 
 export default function plugin(opts?: OptionType) {
   const compiler = (node: { children: Array<MdastNode> }) => {

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -65,10 +65,10 @@ export default function serialize(
     children = chunk.children
       .map((c: BlockType | LeafType) => {
         const isList = !isLeafNode(c)
-          ? LIST_TYPES.includes(c.type || '')
+          ? (LIST_TYPES as string[]).includes(c.type || '')
           : false;
 
-        const selfIsList = LIST_TYPES.includes(chunk.type || '');
+        const selfIsList = (LIST_TYPES as string[]).includes(chunk.type || '');
 
         // Links can have the following shape
         // In which case we don't want to surround
@@ -109,7 +109,9 @@ export default function serialize(
               !(c as BlockType).break,
 
             // track depth of nested lists so we can add proper spacing
-            listDepth: LIST_TYPES.includes((c as BlockType).type || '')
+            listDepth: (LIST_TYPES as string[]).includes(
+              (c as BlockType).type || ''
+            )
               ? listDepth + 1
               : listDepth,
           }

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,25 +1,5 @@
+import { BlockType, defaultNodeTypes, LeafType, NodeTypes } from './ast-types';
 import escapeHtml from 'escape-html';
-
-import { defaultNodeTypes, NodeTypes } from './deserialize';
-
-export interface LeafType {
-  text: string;
-  strikeThrough?: boolean;
-  bold?: boolean;
-  italic?: boolean;
-  code?: boolean;
-  parentType?: string;
-}
-
-export interface BlockType {
-  type: string;
-  parentType?: string;
-  link?: string;
-  caption?: string;
-  language?: string;
-  break?: boolean;
-  children: Array<BlockType | LeafType>;
-}
 
 interface Options {
   nodeTypes: NodeTypes;

--- a/test/deserialize/nestedList.test.ts
+++ b/test/deserialize/nestedList.test.ts
@@ -1,6 +1,8 @@
-import { deserialize } from '../../src';
+import { deserialize, MdastNode } from '../../src';
 import nestedMdast from '../fixtures/nested-list';
 
 it('When the list has paragraph elements', () => {
-  expect(nestedMdast.children.map((k) => deserialize(k))).toMatchSnapshot();
+  expect(
+    nestedMdast.children.map((k) => deserialize(k as MdastNode))
+  ).toMatchSnapshot();
 });

--- a/test/deserialize/thematicBreak.test.ts
+++ b/test/deserialize/thematicBreak.test.ts
@@ -1,8 +1,8 @@
-import { deserialize } from '../../src';
+import { deserialize, MdastNode } from '../../src';
 import thematicBreakast from '../fixtures/thematic-break';
 
 it('When the list has thematic breaks', () => {
   expect(
-    thematicBreakast.children.map((k) => deserialize(k))
+    thematicBreakast.children.map((k) => deserialize(k as MdastNode))
   ).toMatchSnapshot();
 });

--- a/test/serialize/serialize-deserialize.test.ts
+++ b/test/serialize/serialize-deserialize.test.ts
@@ -1,7 +1,7 @@
 import unified from 'unified';
 import parse from 'remark-parse';
 import plugin, { serialize } from '../../src';
-import { LeafType, BlockType } from '../../src/serialize';
+import { LeafType, BlockType } from '../../src/ast-types';
 
 const mdown = `a
 <br>

--- a/test/serialize/serialize-deserialize.test.ts
+++ b/test/serialize/serialize-deserialize.test.ts
@@ -17,11 +17,10 @@ test('Deserialize and serialize mix of break tags and new lines', (done) => {
     .use(parse)
     .use(plugin)
     .process(mdown, (_, file) => {
-      //@ts-ignore ts doesn't know about file.result
-      const res = file.result;
+      const res = file.result as (LeafType | BlockType)[];
       expect(res).toMatchSnapshot();
 
-      const fin = res.map((v: LeafType | BlockType) => serialize(v)).join('');
+      const fin = res.map((v) => serialize(v)).join('');
 
       expect(fin).toEqual(mdown);
       done();
@@ -36,11 +35,10 @@ test('Deserialize heading with new line', (done) => {
     .use(parse)
     .use(plugin)
     .process(headingWithNewLine, (_, file) => {
-      //@ts-ignore ts doesn't know about file.result
-      const res = file.result;
+      const res = file.result as (LeafType | BlockType)[];
       expect(res).toMatchSnapshot();
 
-      const fin = res.map((v: LeafType | BlockType) => serialize(v)).join('');
+      const fin = res.map((v) => serialize(v)).join('');
 
       expect(fin).toEqual(headingWithNewLine);
       done();


### PR DESCRIPTION
It would be peachy to be able to write [discriminated unions](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#discriminated-unions) like:

```ts
type ElementData = {
  type: defaultNodeTypes.ul_list
  value: string[]
} | {
  type: defaultNodeTypes.paragraph
  value: string
}
```

or what have you, but it's impossible to do so because the TS compiler can't distinguish between the types of `ul_list` and `paragraph` even though they are constants. Hopefully others find this PR useful as well!