### PR TITLE
Documentation: Improved Slate to Markdown example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,14 @@ import { serialize } from 'remark-slate';
 export default ({ onChange }) => {
   const [value, setValue] = useState(initialValue);
 
-  React.useEffect(() => {
+  const handleChange = useCallback((nextValue) => {
+		setValue(nextValue);
     // serialize slate state to a markdown string
-    onChange(value.map((v) => serialize(v)).join(''));
-  }, [onChange, value]);
+		onChange(value.map((v) => serialize(v)).join(''));
+	}, [onChange]);
 
   return (
-    <Slate editor={editor} value={value} onChange={(value) => setValue(value)}>
+    <Slate editor={editor} value={value} onChange={handleChange}>
       <Editable
         renderElement={renderElement}
         renderLeaf={renderLeaf}


### PR DESCRIPTION
With the current example the passed in `onChange` callback would be called on mount as well as every time the prop changes, which is probably not what a user wants. (compare for example to `<input>`).
Instead we should call it only when the editor's `onChange` is called, i.e. when the state is supposed to update.