### PR TITLE
Add new line to Decendants of ListItem that are leafNodes

### DIFF
--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -182,6 +182,9 @@ export default function serialize(
 
     case nodeTypes.listItem:
       const isOL = chunk && chunk.parentType === nodeTypes.ol_list;
+      const treatAsLeaf =
+        (chunk as BlockType).children.length === 1 &&
+        isLeafNode((chunk as BlockType).children[0]);
 
       let spacer = '';
       for (let k = 0; listDepth > k; k++) {
@@ -192,7 +195,9 @@ export default function serialize(
           spacer += '  ';
         }
       }
-      return `${spacer}${isOL ? '1.' : '-'} ${children}`;
+      return `${spacer}${isOL ? '1.' : '-'} ${children}${
+        treatAsLeaf ? '\n' : ''
+      }`;
 
     case nodeTypes.paragraph:
       return `${children}\n`;

--- a/test/serialize-deserialize/list.test.ts
+++ b/test/serialize-deserialize/list.test.ts
@@ -1,0 +1,92 @@
+import { serialize, defaultNodeTypes } from '../../src';
+import unified from 'unified';
+import markdown from 'remark-parse';
+import slate from '../../src';
+
+test('slate to markdown, then markdown to slate', async () => {
+  const serializedMarkdown = '\n- foo\n- bar\n- baz\n\n';
+
+  const serialized = serialize({
+    type: defaultNodeTypes.ul_list,
+    children: [
+      {
+        type: defaultNodeTypes.listItem,
+        children: [
+          {
+            text: 'foo',
+          },
+        ],
+      },
+      {
+        type: defaultNodeTypes.listItem,
+        children: [
+          {
+            text: 'bar',
+          },
+        ],
+      },
+      {
+        type: defaultNodeTypes.listItem,
+        children: [
+          {
+            text: 'baz',
+          },
+        ],
+      },
+    ],
+  });
+
+  expect(serialized).toBe(serializedMarkdown);
+
+  const { result } = await unified()
+    .use(markdown)
+    .use(slate)
+    .process(serializedMarkdown);
+
+  expect(result).toStrictEqual([
+    {
+      type: defaultNodeTypes.ul_list,
+      children: [
+        {
+          type: defaultNodeTypes.listItem,
+          children: [
+            {
+              type: defaultNodeTypes.paragraph,
+              children: [
+                {
+                  text: 'foo',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: defaultNodeTypes.listItem,
+          children: [
+            {
+              type: defaultNodeTypes.paragraph,
+              children: [
+                {
+                  text: 'bar',
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: defaultNodeTypes.listItem,
+          children: [
+            {
+              type: defaultNodeTypes.paragraph,
+              children: [
+                {
+                  text: 'baz',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ]);
+});


### PR DESCRIPTION
When decendants of ListItem is a LeafNode, serialize outputs a value that cannot be deserialized back to valid listItems.

This PR fixes that.