### PR TITLE
Add list item content type

### DIFF
--- a/src/ast-types.ts
+++ b/src/ast-types.ts
@@ -6,6 +6,7 @@ export interface NodeTypes {
   ul_list: 'ul_list';
   ol_list: 'ol_list';
   listItem: 'list_item';
+  listItemContent: 'paragraph';
   heading: {
     1: 'heading_one';
     2: 'heading_two';
@@ -47,6 +48,7 @@ export const defaultNodeTypes: NodeTypes = {
   ul_list: 'ul_list',
   ol_list: 'ol_list',
   listItem: 'list_item',
+  listItemContent: 'paragraph',
   heading: {
     1: 'heading_one',
     2: 'heading_two',
@@ -132,6 +134,7 @@ export interface MdastNode {
   spread?: any;
   checked?: any;
   indent?: any;
+  parentType?: MdastNodeType;
 }
 
 export type TextNode = { text?: string | undefined };

--- a/src/deserialize.ts
+++ b/src/deserialize.ts
@@ -43,6 +43,7 @@ export default function deserialize<T extends InputNodeTypes>(
         {
           ...c,
           ordered: node.ordered || false,
+          parentType: node.type,
         },
         opts
       )
@@ -63,7 +64,13 @@ export default function deserialize<T extends InputNodeTypes>(
     case 'listItem':
       return { type: types.listItem, children } as ListItemNode<T>;
     case 'paragraph':
-      return { type: types.paragraph, children } as ParagraphNode<T>;
+      return {
+        type:
+          node.parentType === 'listItem'
+            ? types.listItemContent
+            : types.paragraph,
+        children,
+      } as ParagraphNode<T>;
     case 'link':
       return {
         type: types.link,

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -1,5 +1,5 @@
-import { BlockType, defaultNodeTypes, LeafType, NodeTypes } from './ast-types';
 import escapeHtml from 'escape-html';
+import { BlockType, defaultNodeTypes, LeafType, NodeTypes } from './ast-types';
 
 interface Options {
   nodeTypes: NodeTypes;
@@ -198,7 +198,7 @@ export default function serialize(
       return `${spacer}${isOL ? '1.' : '-'} ${children}${
         treatAsLeaf ? '\n' : ''
       }`;
-
+    case nodeTypes.listItemContent:
     case nodeTypes.paragraph:
       return `${children}\n`;
 


### PR DESCRIPTION
This allows the user to adjust the child node in a list item
It is useful for https://github.com/udecode/plate which has a lic (list-item-content) in the child.

I am unsure whether or not to add tests to this, if this should be done I would greatly appreciate some guidance :)